### PR TITLE
Add support for pentoo live dvd

### DIFF
--- a/src/distribution.c
+++ b/src/distribution.c
@@ -28,6 +28,9 @@ CHAR8* KernelLocationForDistributionName(CHAR8 *name, OUT CHAR8 **boot_folder) {
 	} else if (strcmpa((CHAR8 *)"Ubuntu", name) == 0) {
 		*boot_folder = (CHAR8 *)"casper";
 		return (CHAR8 *)"/casper/vmlinuz.efi";
+	} else if (strcmpa((CHAR8 *)"Pentoo", name) == 0) {
+		*boot_folder = (CHAR8 *)"isolinux";
+		return (CHAR8 *)"/isolinux/pentoo";
 	} else {
 		return (CHAR8 *)"";
 	}
@@ -38,6 +41,8 @@ CHAR8* InitRDLocationForDistributionName(CHAR8 *name) {
 		return (CHAR8 *)"/live/initrd.img";
 	} else if (strcmpa((CHAR8 *)"Ubuntu", name) == 0) {
 		return (CHAR8 *)"/casper/initrd.lz";
+	} else if (strcmpa((CHAR8 *)"Pentoo", name) == 0) {
+		return (CHAR8 *)"/isolinux/pentoo.igz";
 	} else {
 		return (CHAR8 *)"";
 	}


### PR DESCRIPTION
Please note that in order to actually make pentoo work, you will need to add `isoboot=/efi/boot/boot.iso` to the kernel cmdline!

Working enterprise.cfg (does not need this PR):
```
entry Pentoo
iso pentoo-amd64-hardened-2015.0_RC4.6.iso
initrd /isolinux/pentoo.igz
kernel /isolinux/pentoo root=/dev/ram0 init=/linuxrc nox nodhcp aufs max_loop=256 dokeymap looptype=squashfs loop=/image.squashfs cdroot video=uvesafb:mtrr:3,ywrap,1024x768-16 usbcore.autosuspend=1 console=tty0 net.ifnames=0 isoboot=/efi/boot/pentoo-amd64-hardened-2015.0_RC4.6.iso
```